### PR TITLE
Fix ollama command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Prerequisites: a relatively recent version of Rust. (I built it with Rust 1.82, 
 - Fetch [the `phi3` model][model]:
 
     ```sh
-    ollama pull llama3.2
+    ollama pull phi3
     ```
 
 [o]: https://ollama.com

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Prerequisites: a relatively recent version of Rust. (I built it with Rust 1.82, 
 
 - Install and run [ollama][o].
 
-- Fetch [the `llama3.2` model][model]:
+- Fetch [the `phi3` model][model]:
 
     ```sh
-    ollama fetch llama3.2
+    ollama pull llama3.2
     ```
 
 [o]: https://ollama.com
-[model]: https://ollama.com/library/llama3.2
+[model]: https://ollama.com/library/phi3
 
 That’s it; now you can run `jj-gpc` to do this.
 


### PR DESCRIPTION
The `fetch` command doesn't exist and apparently the default model of `jj-gpc` also changed.

I also thought about just pasting the output of `jj-gpc --help` into the README instead of the handcrafted notes that are there currently (and partially out of date) but didn't want to mix the two.