### PR TITLE
Fix dry-run commands to match the actual cli flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ async fn main() {
             "[dry run] jj bookmark create {branch_name} --revision {}",
             args.change
         );
-        println!("[dry run] jj git push --bookmark {branch_name}");
+        println!("[dry run] jj git push --bookmark {branch_name} --allow-new");
         return;
     }
 


### PR DESCRIPTION
`--allow-new` is required for new branches nowadays, so let's document that's being passed by showing it in dry-runs.